### PR TITLE
Use "!file.fail()" instead of "file != NULL"

### DIFF
--- a/libs/core/texturing_old/shadowmap_old.cpp
+++ b/libs/core/texturing_old/shadowmap_old.cpp
@@ -176,7 +176,7 @@ void CqShadowMapOld::LoadZFile()
 	{
 		std::ifstream file( m_strName.c_str(), std::ios::in | std::ios::binary );
 
-		if ( file != NULL )
+		if ( !file.fail() )
 		{
 			// Save a file type and version marker
 			TqPchar origHeader = tokenCast(ZFILE_HEADER);


### PR DESCRIPTION
Compiling with GCC-6 fails with:

`error: no match for ‘operator!=’ (operand types are ‘std::ifstream {aka std::basic_ifstream<char>}’ and ‘long int’)`
`   if ( file != NULL )`

Pre-C++11 defined an implicit cast from ifstream to "void *" and post C++11 replaced it with an explicit cast of ifstream to "bool".  Testing an ifstream with "!ifstream.fail()" works regardless of the C++ dialect.